### PR TITLE
Added browse button to right click "move storage" option. Adds #7

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,8 @@ nosetests.xml
 .mr.developer.cfg
 .project
 .pydevproject
+release
+/deluge-rbb.iml
+/.idea
+/release
+.gitignore

--- a/README.md
+++ b/README.md
@@ -1,9 +1,41 @@
-Remote "browse" button for Deluge
-==========
-
+# Remote "browse" button for Deluge
 This is a plugin for [Deluge](http://deluge-torrent.org) torrent client.
 By default, when started in **client-server mode**, Deluge has no option to choose destination folder for download, you have to enter it by hand.
 The **Remote "browse" button** plugin eliminates this drawback by adding `Browse..` button to *"Add torrent"* dialog. 
 
-[Download](https://github.com/dredkin/deluge-rbb/releases) .egg file for python 2.6 and 2.7.
+## Download
+[Download](https://github.com/dredkin/deluge-rbb/releases) .egg files for python 2.6, 2.7 & 3.4.
 If you have another version of python, make an .egg file by running build.sh or build.bat depending on platform.
+
+You must use the egg for the correct version of python of both your server & client.
+To check which version of Python you are using:
+* Unix: open terminal and type `python --version`.
+* Windows: Go to your deluge installation directory (e.g. D:\Program Files (x86)\Deluge) and look at the version of the deluge folder. This will be in the format `deluge-someDelugeVersionNumber-pyX.Y.egg` 'X.Y' is the version of Python deluge is running.
+
+## Installation
+When running the Deluge daemon, deluged and Deluge client on a separate computers, the plugin must be installed on both computers. When installing the egg through the GTK client it will be placed in the plugins directory of your computer, as well as copied over to the computer running the daemon.
+
+Note: If the Python versions on the server and desktop computer do not match, you will have to copy the egg to the server manually.
+
+For example in the setup below you will have to install the py2.6 egg on the desktop as normal but then manually install the py2.7 egg onto the server.
+
+Windows desktop with Python 2.6 running GTK client.
+Linux server with Python 2.7 running deluged
+
+## Features
+Browse buttons added to:
+* Add torrents dialog (for Download location & move completed location)
+* Move completed in the options tab of the bottom menu bar.
+* Right click menu "Move" dialog.
+
+## Building
+To build yourself you will need to run `python setup.py bdist_egg` to build the egg file.
+
+### Unix
+The included `build.sh` file will build the egg file and copy it to the local plugins folder for testing.
+
+### Windows
+The included `build.bat` file will try to do some fancy stuff with disabling the plugin on the server before copying the egg to the remote server and re-enabling the plugin. The remote functions use programs associated with putty (plink & pscp) to run remote commands and FTP files. You will need to have putty installed & your host configured for [automatic connections](http://the.earth.li/~sgtatham/putty/0.52/htmldoc/Chapter7.html#7.2.2) for this to work. Once this is done change the value of `serverAddr` at the top of the batch file to the name you saved the configuration in putty.
+
+When calling the batch script you can pass in any number of Python versions to build the eggs for.
+e.g. `build.bat "C:\Python26\python.exe" "C:\Python27\python.exe" "C:\Python34\python.exe"`

--- a/browsebutton/data/myMove_storage_dialog.glade
+++ b/browsebutton/data/myMove_storage_dialog.glade
@@ -1,0 +1,195 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<glade-interface>
+  <!-- interface-requires gtk+ 2.10 -->
+  <!-- interface-naming-policy toplevel-contextual -->
+  <widget class="GtkDialog" id="move_storage_dialog">
+    <property name="width_request">500</property>
+    <property name="can_focus">False</property>
+    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+    <property name="border_width">5</property>
+    <property name="title" translatable="yes">Move Storage</property>
+    <property name="window_position">center-on-parent</property>
+    <property name="destroy_with_parent">True</property>
+    <property name="type_hint">dialog</property>
+    <child internal-child="vbox">
+      <widget class="GtkVBox" id="dialog-vbox4">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+        <property name="spacing">2</property>
+        <child internal-child="action_area">
+          <widget class="GtkHButtonBox" id="dialog-action_area4">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+            <property name="layout_style">end</property>
+            <child>
+              <widget class="GtkButton" id="button_cancel">
+                <property name="label">gtk-cancel</property>
+                <property name="response_id">-6</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="receives_default">True</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="use_stock">True</property>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkButton" id="button_ok">
+                <property name="label">gtk-ok</property>
+                <property name="response_id">-5</property>
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="can_default">True</property>
+                <property name="has_default">True</property>
+                <property name="receives_default">True</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="use_stock">True</property>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+          </widget>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="pack_type">end</property>
+            <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <widget class="GtkVBox" id="vbox1">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+            <property name="spacing">5</property>
+            <child>
+              <widget class="GtkHBox" id="hbox1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="spacing">5</property>
+                <child>
+                  <widget class="GtkImage" id="image1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                    <property name="stock">gtk-save-as</property>
+                  </widget>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkLabel" id="label1">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                    <property name="label" translatable="yes">&lt;b&gt;Move Storage&lt;/b&gt;</property>
+                    <property name="use_markup">True</property>
+                  </widget>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkHSeparator" id="hseparator1">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <widget class="GtkHBox" id="hbox2">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                <property name="spacing">5</property>
+                <child>
+                  <widget class="GtkLabel" id="label2">
+                    <property name="visible">True</property>
+                    <property name="can_focus">False</property>
+                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                    <property name="label" translatable="yes">Destination:</property>
+                  </widget>
+                  <packing>
+                    <property name="expand">False</property>
+                    <property name="fill">False</property>
+                    <property name="position">0</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkEntry" id="entry_destination">
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="has_focus">True</property>
+                    <property name="is_focus">True</property>
+                    <property name="events">GDK_POINTER_MOTION_MASK | GDK_POINTER_MOTION_HINT_MASK | GDK_BUTTON_PRESS_MASK | GDK_BUTTON_RELEASE_MASK</property>
+                    <property name="activates_default">True</property>
+                    <property name="truncate_multiline">True</property>
+                    <property name="primary_icon_activatable">False</property>
+                    <property name="secondary_icon_activatable">False</property>
+                    <property name="primary_icon_sensitive">True</property>
+                    <property name="secondary_icon_sensitive">True</property>
+                  </widget>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">1</property>
+                  </packing>
+                </child>
+                <child>
+                  <widget class="GtkButton" id="browse">
+                    <property name="label" translatable="yes">Browse</property>
+                    <property name="visible">True</property>
+                    <property name="can_focus">True</property>
+                    <property name="receives_default">True</property>
+                  </widget>
+                  <packing>
+                    <property name="expand">True</property>
+                    <property name="fill">True</property>
+                    <property name="position">2</property>
+                  </packing>
+                </child>
+              </widget>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </widget>
+          <packing>
+            <property name="expand">True</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+      </widget>
+    </child>
+  </widget>
+</glade-interface>

--- a/browsebutton/gtkui.py
+++ b/browsebutton/gtkui.py
@@ -224,12 +224,14 @@ class GtkUI(GtkPluginBase):
         menu.set_label("Move Storage")
         menu.show()
         menu.connect("activate", self.on_menu_activated, None)
+        count = 0
         #Remove the original move button
         for item in torrentmenu.get_children():
             if item.get_name() == "menuitem_move":
                 torrentmenu.remove(item)
+                count = count + 1
         #Insert into original "move" position
-        torrentmenu.insert(menu,15)
+        torrentmenu.insert(menu,count)
 
     def on_menu_activated(self, widget=None, data=None):
         log.debug("Item clicked")

--- a/browsebutton/gtkui.py
+++ b/browsebutton/gtkui.py
@@ -215,7 +215,7 @@ class GtkUI(GtkPluginBase):
                  'completed_tab' : { 'id' : 'entry_move_completed' , 'editbox': None, 'widget': None , 'window': None} }
         self.makeButtons()
         self.addMoveMenu()
-        self.handleError
+        self.handleError()
 
     def addMoveMenu(self):
         global menu
@@ -227,9 +227,10 @@ class GtkUI(GtkPluginBase):
         count = 0
         #Remove the original move button
         for item in torrentmenu.get_children():
+            count = count + 1
             if item.get_name() == "menuitem_move":
                 torrentmenu.remove(item)
-                count = count + 1
+                break
         #Insert into original "move" position
         torrentmenu.insert(menu,count)
 

--- a/browsebutton/gtkui.py
+++ b/browsebutton/gtkui.py
@@ -44,8 +44,10 @@ from deluge.ui.client import client
 from deluge.plugins.pluginbase import GtkPluginBase
 import deluge.component as component
 import deluge.common
+import deluge.ui.gtkui.menubar
 
 importError = None
+
 try:
     import pkg_resources
     import common
@@ -123,7 +125,7 @@ class BrowseDialog:
         if not results[1]:
             pixbuf = gtk.icon_theme_get_default().load_icon("go-up", 24, 0)
             self.liststore.append([pixbuf, ".."])
-        subfolders = [] 
+        subfolders = []
         for folder in results[2]:
             subfolders.append(folder)
         subfolders.sort(key=caseInsensitive)
@@ -135,19 +137,22 @@ class BrowseDialog:
     def subfolder_activated(self, widget, path):
         subfolder = self.liststore.get_value(self.liststore.get_iter(path),1)
         self.refillList(subfolder)
-        
+
     def recent_chosed(self, combobox):
         model = combobox.get_model()
         index = combobox.get_active()
         if index != None:
             self.selectedfolder = str(model[index][0])
             self.refillList("")
-        
+
 class GtkUI(GtkPluginBase):
     error = None
     buttons = None
     addDialog = None
+    global menu
+    menu = None
     mainWindow = None
+    moveWindow = None
     recent = []
     def enable(self):
         self.error = importError
@@ -156,10 +161,15 @@ class GtkUI(GtkPluginBase):
         self.handleError()
 
     def disable(self):
+        global menu
+        global sep
+        log.debug("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
         self.error = None
         component.get("Preferences").remove_page("Browse Button")
         component.get("PluginManager").deregister_hook("on_apply_prefs", self.on_apply_prefs)
         component.get("PluginManager").deregister_hook("on_show_prefs", self.on_show_prefs)
+        component.get("PluginManager").remove_torrentmenu_item(menu)
+        component.get("PluginManager").remove_torrentmenu_item(sep)
         for name in self.buttons.keys() :
           self.deleteButton(self.buttons[name]['widget'])
           self.buttons[name]['widget'] = None
@@ -170,6 +180,8 @@ class GtkUI(GtkPluginBase):
             showMessage(None, self.error)
         self.error = None
 
+
+
     def on_apply_prefs(self):
         log.debug("RBB:applying prefs for browsebutton")
         config = {
@@ -179,6 +191,7 @@ class GtkUI(GtkPluginBase):
 
     def on_show_prefs(self):
         client.browsebutton.get_config().addCallback(self.cb_get_config)
+        log.debug("Im here, showing prefs")
 
     def cb_get_config(self, config):
         """callback for on show_prefs"""
@@ -201,17 +214,96 @@ class GtkUI(GtkPluginBase):
         if "recent" in config:
             self.recent = list(config["recent"])
 
+    def on_menuitem_move_activate():
+        log.debug("asdasdsadsasds")
+
     def initializeGUI(self):
         self.glade = gtk.glade.XML(common.get_resource("config.glade"))
         self.load_recent()
         component.get("Preferences").add_page("Browse Button", self.glade.get_widget("prefs_box"))
         component.get("PluginManager").register_hook("on_apply_prefs", self.on_apply_prefs)
         component.get("PluginManager").register_hook("on_show_prefs", self.on_show_prefs)
+
         self.buttons = { 'store' : { 'id': 'entry_download_path' , 'editbox': None, 'widget': None , 'window': None}, \
                      'completed' : { 'id' : 'entry_move_completed_path' , 'editbox': None, 'widget': None , 'window': None}, \
                  'completed_tab' : { 'id' : 'entry_move_completed' , 'editbox': None, 'widget': None , 'window': None} }
         self.makeButtons()
+        self.addMoveMenu()
         self.handleError
+
+    def addMoveMenu(self):
+        global menu
+        global sep
+        torrentmenu = component.get("MenuBar").torrentmenu
+        menu = gtk.CheckMenuItem(_("Move Storage Advanced"))
+        menu.show()
+        log.debug("------------------------------------------------------------------------------------------------")
+        menu.connect("activate", self.on_menu_activated, None)
+
+
+
+        sep = component.get("PluginManager").add_torrentmenu_separator()
+        torrentmenu.append(menu)
+
+
+    def on_menu_activated(self, widget=None, data=None):
+        log.debug("Item clicked")
+
+        #self.show_move_storage_dialog(component.get("TorrentView").get_torrent_state(component.get("TorrentView").get_selected_torrent()))
+        client.core.get_torrent_status(component.get("TorrentView").get_selected_torrent(), ["save_path"]).addCallback(self.show_move_storage_dialog)
+
+    def show_move_storage_dialog(self, status):
+        log.debug("show_move_storage_dialog")
+        glade = gtk.glade.XML(pkg_resources.resource_filename(
+            "deluge.ui.gtkui", "glade/move_storage_dialog.glade"
+        ))
+
+        glade = gtk.glade.XML(common.get_resource("myMove_storage_dialog.glade"))
+
+
+        # Keep it referenced:
+        #  https://bugzilla.gnome.org/show_bug.cgi?id=546802
+        self.move_storage_dialog = glade.get_widget("move_storage_dialog")
+        self.move_storage_dialog.set_transient_for(component.get("MainWindow").window)
+        self.move_storage_dialog_entry = glade.get_widget("entry_destination")
+        self.move_storage_browse_button = glade.get_widget("browse")
+        self.move_storage_entry_destination = glade.get_widget("entry_destination")
+        log.debug("------------------------------------------------------------------------------------------------")
+        log.debug(status)
+
+        self.move_storage_dialog_entry.set_text(status["save_path"])
+        def on_dialog_response_event(widget, response_id):
+
+            def on_core_result(result):
+                # Delete references
+                del self.move_storage_dialog
+                del self.move_storage_dialog_entry
+
+            if response_id == gtk.RESPONSE_OK:
+                log.debug("Moving torrents to %s",
+                          self.move_storage_dialog_entry.get_text())
+                path = self.move_storage_dialog_entry.get_text()
+                client.core.move_storage(
+                    component.get("TorrentView").get_selected_torrents(), path
+                ).addCallback(on_core_result)
+            self.move_storage_dialog.hide()
+
+
+        def browseClicked(something):
+            log.debug(something)
+            self.chooseFolder(self.move_storage_entry_destination, None)
+
+
+        self.move_storage_dialog.connect("response", on_dialog_response_event)
+        self.move_storage_browse_button.connect("clicked", browseClicked)
+
+        self.move_storage_dialog.show()
+
+
+
+
+
+
 
     def addButton(self, editbox, onClickEvent):
         """Adds a Button to the editbox inside hbox container."""
@@ -267,7 +359,7 @@ class GtkUI(GtkPluginBase):
         if editbox is None:
             self.error = id + " not found!"
         return editbox
-        
+
     def makeButtons(self):
         if not self.findMainWindow():
             self.handleError()
@@ -275,6 +367,7 @@ class GtkUI(GtkPluginBase):
         if not self.findAddDialog():
             self.handleError()
             return False
+
         self.buttons['store']['window'] = self.addDialog
         self.buttons['completed']['window'] = self.addDialog
         self.buttons['completed_tab']['window'] = self.mainWindow
@@ -299,6 +392,7 @@ class GtkUI(GtkPluginBase):
         dialog.dialog.destroy()
 
     def on_browse_button_clicked(self, widget):
+        log.debug("Button clicked")
         for name in self.buttons.keys() :
             if widget == self.buttons[name]['widget']:
                 return self.chooseFolder(self.buttons[name]['editbox'], self.buttons[name]['window'])

--- a/browsebutton/gtkui.py
+++ b/browsebutton/gtkui.py
@@ -44,10 +44,8 @@ from deluge.ui.client import client
 from deluge.plugins.pluginbase import GtkPluginBase
 import deluge.component as component
 import deluge.common
-import deluge.ui.gtkui.menubar
 
 importError = None
-
 try:
     import pkg_resources
     import common
@@ -66,6 +64,7 @@ def findwidget(container, name):
               return ret
     return None
 
+
 def showMessage(parent, message):
     if parent is None:
         parent = component.get("MainWindow").window
@@ -74,8 +73,10 @@ def showMessage(parent, message):
     md.run()
     md.destroy()
 
+
 def caseInsensitive(key):
     return key.lower()
+
 
 class BrowseDialog:
     def __init__(self, path, recent, parent):
@@ -149,10 +150,7 @@ class GtkUI(GtkPluginBase):
     error = None
     buttons = None
     addDialog = None
-    global menu
-    menu = None
     mainWindow = None
-    moveWindow = None
     recent = []
     def enable(self):
         self.error = importError
@@ -161,15 +159,10 @@ class GtkUI(GtkPluginBase):
         self.handleError()
 
     def disable(self):
-        global menu
-        global sep
-        log.debug("^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^")
         self.error = None
-        component.get("Preferences").remove_page("Browse Button")
-        component.get("PluginManager").deregister_hook("on_apply_prefs", self.on_apply_prefs)
-        component.get("PluginManager").deregister_hook("on_show_prefs", self.on_show_prefs)
-        component.get("PluginManager").remove_torrentmenu_item(menu)
-        component.get("PluginManager").remove_torrentmenu_item(sep)
+        #component.get("Preferences").remove_page("Browse Button")
+        #component.get("PluginManager").deregister_hook("on_apply_prefs", self.on_apply_prefs)
+        #component.get("PluginManager").deregister_hook("on_show_prefs", self.on_show_prefs)
         for name in self.buttons.keys() :
           self.deleteButton(self.buttons[name]['widget'])
           self.buttons[name]['widget'] = None
@@ -180,8 +173,6 @@ class GtkUI(GtkPluginBase):
             showMessage(None, self.error)
         self.error = None
 
-
-
     def on_apply_prefs(self):
         log.debug("RBB:applying prefs for browsebutton")
         config = {
@@ -191,7 +182,6 @@ class GtkUI(GtkPluginBase):
 
     def on_show_prefs(self):
         client.browsebutton.get_config().addCallback(self.cb_get_config)
-        log.debug("Im here, showing prefs")
 
     def cb_get_config(self, config):
         """callback for on show_prefs"""
@@ -214,16 +204,12 @@ class GtkUI(GtkPluginBase):
         if "recent" in config:
             self.recent = list(config["recent"])
 
-    def on_menuitem_move_activate():
-        log.debug("asdasdsadsasds")
-
     def initializeGUI(self):
         self.glade = gtk.glade.XML(common.get_resource("config.glade"))
         self.load_recent()
-        component.get("Preferences").add_page("Browse Button", self.glade.get_widget("prefs_box"))
-        component.get("PluginManager").register_hook("on_apply_prefs", self.on_apply_prefs)
-        component.get("PluginManager").register_hook("on_show_prefs", self.on_show_prefs)
-
+        #component.get("Preferences").add_page("Browse Button", self.glade.get_widget("prefs_box"))
+        #component.get("PluginManager").register_hook("on_apply_prefs", self.on_apply_prefs)
+        #component.get("PluginManager").register_hook("on_show_prefs", self.on_show_prefs)
         self.buttons = { 'store' : { 'id': 'entry_download_path' , 'editbox': None, 'widget': None , 'window': None}, \
                      'completed' : { 'id' : 'entry_move_completed_path' , 'editbox': None, 'widget': None , 'window': None}, \
                  'completed_tab' : { 'id' : 'entry_move_completed' , 'editbox': None, 'widget': None , 'window': None} }
@@ -233,44 +219,29 @@ class GtkUI(GtkPluginBase):
 
     def addMoveMenu(self):
         global menu
-        global sep
         torrentmenu = component.get("MenuBar").torrentmenu
-        menu = gtk.CheckMenuItem(_("Move Storage Advanced"))
+        menu = gtk.ImageMenuItem(gtk.STOCK_SAVE_AS, 'Move Storage Advanced')
+        menu.set_label("Move Storage")
         menu.show()
-        log.debug("------------------------------------------------------------------------------------------------")
         menu.connect("activate", self.on_menu_activated, None)
-
-
-
-        sep = component.get("PluginManager").add_torrentmenu_separator()
-        torrentmenu.append(menu)
-
+        #Remove the original move button
+        for item in torrentmenu.get_children():
+            if item.get_name() == "menuitem_move":
+                torrentmenu.remove(item)
+        #Insert into original "move" position
+        torrentmenu.insert(menu,15)
 
     def on_menu_activated(self, widget=None, data=None):
         log.debug("Item clicked")
-
-        #self.show_move_storage_dialog(component.get("TorrentView").get_torrent_state(component.get("TorrentView").get_selected_torrent()))
         client.core.get_torrent_status(component.get("TorrentView").get_selected_torrent(), ["save_path"]).addCallback(self.show_move_storage_dialog)
 
     def show_move_storage_dialog(self, status):
-        log.debug("show_move_storage_dialog")
-        glade = gtk.glade.XML(pkg_resources.resource_filename(
-            "deluge.ui.gtkui", "glade/move_storage_dialog.glade"
-        ))
-
         glade = gtk.glade.XML(common.get_resource("myMove_storage_dialog.glade"))
-
-
-        # Keep it referenced:
-        #  https://bugzilla.gnome.org/show_bug.cgi?id=546802
         self.move_storage_dialog = glade.get_widget("move_storage_dialog")
         self.move_storage_dialog.set_transient_for(component.get("MainWindow").window)
         self.move_storage_dialog_entry = glade.get_widget("entry_destination")
         self.move_storage_browse_button = glade.get_widget("browse")
         self.move_storage_entry_destination = glade.get_widget("entry_destination")
-        log.debug("------------------------------------------------------------------------------------------------")
-        log.debug(status)
-
         self.move_storage_dialog_entry.set_text(status["save_path"])
         def on_dialog_response_event(widget, response_id):
 
@@ -288,21 +259,11 @@ class GtkUI(GtkPluginBase):
                 ).addCallback(on_core_result)
             self.move_storage_dialog.hide()
 
-
         def browseClicked(something):
-            log.debug(something)
             self.chooseFolder(self.move_storage_entry_destination, None)
-
-
         self.move_storage_dialog.connect("response", on_dialog_response_event)
         self.move_storage_browse_button.connect("clicked", browseClicked)
-
         self.move_storage_dialog.show()
-
-
-
-
-
 
 
     def addButton(self, editbox, onClickEvent):
@@ -392,7 +353,6 @@ class GtkUI(GtkPluginBase):
         dialog.dialog.destroy()
 
     def on_browse_button_clicked(self, widget):
-        log.debug("Button clicked")
         for name in self.buttons.keys() :
             if widget == self.buttons[name]['widget']:
                 return self.chooseFolder(self.buttons[name]['editbox'], self.buttons[name]['window'])

--- a/build.bat
+++ b/build.bat
@@ -1,12 +1,69 @@
+REM set this variable equal to your putty saved session name.
+set serverAddr=PuttySavedSessionName
+
+rem stop plugin on deluge deamon
+plink %serverAddr% deluge-console plugin -s
+plink %serverAddr% deluge-console plugin -d browseButton
+
+rem Kill deluge if already running
 taskkill /f /im deluged-debug.exe
 taskkill /f /im deluge-debug.exe
-set scriptdrive=%~d0
-set scriptpath=%~p0
-if "%ProgramFiles(x86)%"=="" (set delugepath="%ProgramFiles%") else (set delugepath="%ProgramFiles(x86)%")
+taskkill /f /im deluge.exe
 
-%scriptdrive%
-cd %scriptdrive%%scriptpath%
-python setup.py bdist_egg
-copy dist\* %APPDATA%\deluge\plugins
+rem remove the release directory
+rd /s /q "release\"
 
-REM %delugepath%\Deluge\deluge-debug.exe
+rem create the egg files
+IF NOT %~1 == "" (
+    ECHO building with custom python
+
+    setlocal enabledelayedexpansion
+
+    set argCount=0
+
+    for %%x in (%*) do (
+        set /A argCount+=1
+        set "argVec[!argCount!]=%%~x"
+        echo Arg = "%%~x"
+    )
+
+    echo Number of processed arguments: !argCount!
+
+    for /L %%i in (1,1,!argCount!) do (
+        echo Running as : !argVec[%%i]! setup.py bdist_egg
+        !argVec[%%i]! setup.py bdist_egg
+    )
+) ELSE (
+    ECHO building with default python
+    python setup.py bdist_egg
+)
+
+rem copy to the release directory
+md "release"
+XCOPY  /y /E  "dist" "release\dist\"
+XCOPY  /y /E "browsebutton.egg-info" "release\browsebutton.egg-info\"
+XCOPY  /y /E "build" "release\build\"
+
+rem remove origional files from root dir
+rmdir /s /q "dist\"
+rmdir /s /q "browsebutton.egg-info\"
+rmdir /s /q "build\"
+
+rem copy egg to deluge dir
+copy release\dist\* %APPDATA%\deluge\plugins
+
+rem copy to plugins dir
+copy release\dist\* "D:\Program Files (x86)\Deluge\deluge-1.3.11-py2.7.egg\deluge\plugins"
+
+rem copy plugin to server
+for %%x in (release/dist/*.egg) do (
+    pscp release/dist/%%x %serverAddr%:.config/deluge/plugins
+)
+
+rem start plugin on deluge server
+plink %serverAddr% deluge-console plugin -e browseButton
+plink %serverAddr% deluge-console plugin -s
+
+rem laubch deluge in debug mode
+"D:\Program Files (x86)\Deluge\deluge-debug.exe" -L debug
+pause

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools import setup
 __plugin_name__ = "browsebutton"
 __author__ = "dredkin"
 __author_email__ = "dmitry.redkin@gmail.com"
-__version__ = "0.1.8"
+__version__ = "0.1.9"
 __url__ = "https://github.com/dredkin/deluge-rbb/releases"
 __license__ = "GPLv3"
 __description__ = "Browse Button for Client/Server Mode"

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ from setuptools import setup
 __plugin_name__ = "browsebutton"
 __author__ = "dredkin"
 __author_email__ = "dmitry.redkin@gmail.com"
-__version__ = "0.1.7"
+__version__ = "0.1.8"
 __url__ = "https://github.com/dredkin/deluge-rbb/releases"
 __license__ = "GPLv3"
 __description__ = "Browse Button for Client/Server Mode"


### PR DESCRIPTION
This push adds a browse option to the right click, "move storage" button. It does this by adding a new menu item to the right click contect menu called "Move Storage Advanced" as this runs the same code as the normal move dialogue button but has an extra browse button included. Unfortunatly I could not remove the origional 'move storage' button from the right click menu so there are two buttons to move a files location (could be changed later).

Feature request from [#7](https://github.com/dredkin/deluge-rbb/issues/7)

![Image 1](http://i.imgur.com/Nkks5eo.png "Image 1")
![Image 2](http://i.imgur.com/yqGgXZ3.png "Image 2")